### PR TITLE
회원가입 UI

### DIFF
--- a/frontend/lib/feature/login/login_screen.dart
+++ b/frontend/lib/feature/login/login_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
 import '../my_page/my_page_screen.dart';
+import 'package:book_chat/feature/sign_up/signup_screen.dart';
 
 class LoginScreen extends ConsumerStatefulWidget {
   const LoginScreen({Key? key}) : super(key: key);
@@ -131,6 +132,18 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                         ),
                       )
                     : const Text('로그인'),
+              ),
+              const SizedBox(height: 3),  // 버튼 사이 간격
+              ElevatedButton(
+                onPressed: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (context) => SignUpScreen(),
+                    ),
+                  );
+                },
+                child: const Text('회원가입'),
               ),
             ],
           ),

--- a/frontend/lib/feature/sign_up/signup_screen.dart
+++ b/frontend/lib/feature/sign_up/signup_screen.dart
@@ -2,6 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 class SignUpScreen extends ConsumerStatefulWidget{
+  static final emailRegex = RegExp(r'^[a-zA-Z0-9.]+@[a-zA-Z0-9]+\.[a-zA-Z]+');
+  static final passwordRegex = RegExp(r'^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{8,}$');
+  static final nameRegex = RegExp(r'^[a-zA-Z][a-zA-Z0-9]*$');
+
   final TextEditingController emailController = TextEditingController();
   final TextEditingController passwordController = TextEditingController();
   final TextEditingController nameController = TextEditingController();
@@ -12,6 +16,8 @@ class SignUpScreen extends ConsumerStatefulWidget{
 }
 
 class _SignUpScreenState extends ConsumerState<SignUpScreen>{
+  final _formKey = GlobalKey<FormState>();
+
   @override
   void dispose() {
     widget.emailController.dispose();
@@ -26,41 +32,71 @@ class _SignUpScreenState extends ConsumerState<SignUpScreen>{
       appBar: AppBar(
         title: const Text("회원가입"),
       ),
-      body: Column(
+    body: Form(
+    key: _formKey,
+    child: Column(
         children: [
-          TextField(
+          TextFormField(
             controller: widget.emailController,
-            decoration: const InputDecoration(
+            decoration: InputDecoration(
               labelText: '이메일',
+              hintText: 'example@email.com',
             ),
+            validator: (value) {
+              if (value == null || value.isEmpty) {
+                return '이메일을 입력해주세요';
+              }
+              if (!SignUpScreen.emailRegex.hasMatch(value)) {
+                return '올바른 이메일 형식이 아닙니다';
+              }
+              return null;
+            },
           ),
-          TextField(
+          TextFormField(
             controller: widget.passwordController,
-            decoration: const InputDecoration(
+            decoration: InputDecoration(
               labelText: '비밀번호',
+              hintText: '8자 이상, 특수문자 포함',
             ),
+            obscureText: true, // 가려져서 보임
+            validator: (value) {
+              if (value == null || value.isEmpty) {
+                return '비밀번호를 입력해주세요';
+              }
+              if (!SignUpScreen.passwordRegex.hasMatch(value)) {
+                return '비밀번호는 8자 이상, 영문, 숫자, 특수문자를 포함해야 합니다';
+              }
+              return null;
+            },
           ),
-          TextField(
+          TextFormField(
             controller: widget.nameController,
             decoration: const InputDecoration(
               labelText: '이름',
             ),
+            validator: (value) {
+              if (value == null || value.isEmpty) {
+                return '이름을 입력해주세요';
+              }
+              if (!SignUpScreen.nameRegex.hasMatch(value)) {
+                return '이름은 첫 글자로 숫자를 사용할 수 없습니다';
+              }
+              return null;
+            },
           ),
 
           ElevatedButton(
-            onPressed: (){},
-            // async {
-            //   ref.read(signUpProvider.notifier).signUp(
-            //     email: widget.emailController.text,
-            //     password: widget.passwordController.text,
-            //     name: widget.nameController.text,
-            //     activity: widget.activityController.text,
-            //   );
-            // },
-            child: const Text("회원가입"),
+            onPressed: (){
+              if (_formKey.currentState!.validate()) {
+                // 유효성 검사 통과시 처리할 로직
+                print('폼 검증 성공');
+              }
+            },
+            child: const Text('가입하기'),
           ),
         ],
       ),
+    )
     );
   }
 }

--- a/frontend/lib/feature/sign_up/signup_screen.dart
+++ b/frontend/lib/feature/sign_up/signup_screen.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class SignUpScreen extends ConsumerStatefulWidget{
+  final TextEditingController emailController = TextEditingController();
+  final TextEditingController passwordController = TextEditingController();
+  final TextEditingController nameController = TextEditingController();
+  SignUpScreen({super.key});
+
+  @override
+  ConsumerState<ConsumerStatefulWidget> createState() => _SignUpScreenState();
+}
+
+class _SignUpScreenState extends ConsumerState<SignUpScreen>{
+  @override
+  void dispose() {
+    widget.emailController.dispose();
+    widget.passwordController.dispose();
+    widget.nameController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text("회원가입"),
+      ),
+      body: Column(
+        children: [
+          TextField(
+            controller: widget.emailController,
+            decoration: const InputDecoration(
+              labelText: '이메일',
+            ),
+          ),
+          TextField(
+            controller: widget.passwordController,
+            decoration: const InputDecoration(
+              labelText: '비밀번호',
+            ),
+          ),
+          TextField(
+            controller: widget.nameController,
+            decoration: const InputDecoration(
+              labelText: '이름',
+            ),
+          ),
+
+          ElevatedButton(
+            onPressed: (){},
+            // async {
+            //   ref.read(signUpProvider.notifier).signUp(
+            //     email: widget.emailController.text,
+            //     password: widget.passwordController.text,
+            //     name: widget.nameController.text,
+            //     activity: widget.activityController.text,
+            //   );
+            // },
+            child: const Text("회원가입"),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
1. 기존 로그인 화면 (feature/login/login_screen.dart) 에서는 로그인 버튼만 있었는데, 로그인 버튼 밑에 회원가입 버튼 추가. 
  - _LoginScreenState 클래스의 build 메서드에 추가
  - 세로 형태로 UI를 구성할 수 있는 Column 위젯의 children 리스트에 빈칸과 회원가입 버튼 추가
  - 빈칸은 const SizedBox, 회원가입 버튼은 로그인 버튼과 동일한 ElevatedButton 위젯 사용 

2. 회원가입을 위한 폴더와 파일 추가 (feature/sign_up/signup_screen.dart)
  - 재혁님 코드 참고하여 복붙 (edu 리포지토리의 lib/state/feature/sign_up/sign_up_screen.dart)
  - 리버팟으로 상태관리가 되어있고, 회원 가입 후 상태가 변하기 때문에 ConsumerStatefulWidget 를 상속하여 사용
  - 회원가입 정보(이메일, 비밀번호, 이름)를 입력하고 회원 가입을 위한 버튼의 코드는 주석 처리 해둠 (파이어베이스가 아니라 Django에 맞게 변경 예정) 
